### PR TITLE
add new deploy git action to aws

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -1,0 +1,44 @@
+name: Deploy PROD digital.ca.gov
+# site:  development.digital.ca.gov
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build_deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: n1hility/cancel-previous-runs@v2
+        with: 
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v3.0.0
+      - name: Use Node.js 16.13.1
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.13.1
+      - name: Build Site
+        run: |
+          npm install
+          npm run build
+      # Push built site files to S3 production bucket    
+      - name: Deploy to S3
+        uses: jakejarvis/s3-sync-action@v0.5.1
+        with:
+          args: --follow-symlinks --delete
+        env:
+          AWS_S3_BUCKET: 'digital.ca.gov'
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: 'us-west-1'   # optional: defaults to us-east-1
+          SOURCE_DIR: ./_site # only move built directory
+
+      # Invalidate Cloudfront production distribution
+      - name: invalidate
+        uses: chetan/invalidate-cloudfront-action@v1.3
+        env:
+          DISTRIBUTION: 'E1KO87RQFUTIBK'
+          PATHS: '/*'
+          AWS_REGION: 'us-west-1'
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}             


### PR DESCRIPTION
This is a new git action which will deploy the built site to an AWS environment

We are preparing to do a hosting migration from github pages to AWS for digital.ca.gov

FYI the migration steps we will be following are:
- Add build and deploy steps to all relevant branches
- Verify site is built and deployed correctly 
- Setup all S3 buckets and CloudFronts required
- Request missing https certificates from AWS
- Get new certs validated with DNS updates from CDT
- Request new DNS records
 - Apply approved certs to new CloudFronts
 - Request existing DNS record update so it points to AWS instead of github pages