### PR TITLE
speed improvements

### DIFF
--- a/pages/_includes/analytics.njk
+++ b/pages/_includes/analytics.njk
@@ -4,5 +4,11 @@ ga('create', 'UA-20973992-35', 'auto'); // my specific site
 ga('create', 'UA-3419582-2', 'auto', 'tracker2'); // all ca.gov
 ga('send', 'pageview');
 ga('tracker2.send', 'pageview');
+
+window.onload = function() {
+  let s = document.createElement("script");
+  s.type = "text/javascript";
+  s.src = "https://www.google-analytics.com/analytics.js";
+  document.head.append(s);
+}
 </script>
-<script async defer src='https://www.google-analytics.com/analytics.js'></script>

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -3,8 +3,18 @@
 @import 'theme-tokens'; /* theme colors */
 
 /* noto serif font used for headers */
-@import url('https://fonts.googleapis.com/css2?family=Noto+Serif:wght@700&display=swap');
-
+// the following lines would come from
+// @import url('https://fonts.googleapis.com/css2?family=Noto+Serif:wght@700&display=swap');
+/* latin */
+@font-face {
+  font-family: 'Noto Serif';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/notoserif/v21/ga6Law1J5X9T9RW6j9bNdOwzfReece9LOoc.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;  
+}
+  
 /* sitewide styles */
 @import '../../node_modules/@cagov/ds-base-css/src/core';
 


### PR DESCRIPTION
Tested the following things on a real network on development instance and they measurably improve first contentful paint scores on slower devices
- remove font network request by hardcoding just the used glyph set
- delay GA call because it will get in the way of render otherwise even when using defer on the script tag. This was tested with live GA collection and does not prevent GA noticing traffic