### PR TITLE
add do not crawl support

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -111,6 +111,7 @@ module.exports = function (eleventyConfig) {
         item.data.publishdate = jsonData.date.split("T")[0]; //new Date(jsonData.modified_gmt)
         item.data.meta = jsonData.excerpt;
         item.data.description = jsonData.excerpt;
+        item.data.tags = jsonData.tags;
 
         // WordPress will lazy load everything and you have to put php code in your theme to override it. We don't want to lazy load our featuref image
         item.template.frontMatter.content = item.template.frontMatter.content.replace('loading="lazy" class="cagov-featured-image','class="cagov-featured-image');
@@ -174,6 +175,9 @@ module.exports = function (eleventyConfig) {
   });
   // eleventyConfig.addPlugin(pluginRss);
 
+  eleventyConfig.addFilter('includes', (items, value) => {
+    return (items || []).includes(value);
+  });
   eleventyConfig.addFilter("changeDomain", function (url, domain) {
     try {      
       let host = config.build.canonical_url.split("//"); // TEMP Cheat to get https

--- a/pages/_includes/base-layout.njk
+++ b/pages/_includes/base-layout.njk
@@ -12,6 +12,9 @@
 
     <meta name="description" content="{{ data.og_meta.page_description | striptags }}" />
     <link rel="icon" href="/img/favicon.png">
+    {%- if tags | includes("do-not-crawl") %}
+    <meta name="robots" content="noindex">
+    {%- endif %}
 
     <!-- OG tags -->
     <meta property="og:description" content="{{ data.og_meta.open_graph_description | striptags }}" />


### PR DESCRIPTION
Add the noindex meta tag to the page if the "do-not-crawl" tag is added to the WordPress page