### PR TITLE
add offsite ga link tracking events

### DIFF
--- a/src/js/ga-tracking.js
+++ b/src/js/ga-tracking.js
@@ -1,0 +1,27 @@
+document.querySelectorAll('a').forEach((a) => {
+  // look for and track anchor and pdf links
+  if(a.href.indexOf(window.location.hostname) > -1) {
+    if(a.href.indexOf('.pdf') > -1) {
+      a.addEventListener('click',function() {
+        reportGA('pdf', this.href.split(window.location.hostname)[1])
+      });    
+    }
+    if(a.href.indexOf('#') > -1) {
+      a.addEventListener('click',function() {
+        reportGA('anchor', this.href.split(window.location.hostname)[1])
+      });    
+    }
+  }
+  // look for offsite links
+  if(a.href.indexOf(window.location.origin) === -1 && a.href.indexOf('http') > -1) { // we are looking at a different protocol + hostname, ignoring tel: links
+    a.addEventListener('click',function() {
+      reportGA('offsite', this.href)
+    })          
+  }
+});
+
+window.reportGA = function(eventAction, eventLabel, eventCategory = 'click') {
+  if(typeof(ga) !== 'undefined') {
+    ga('send', 'event', eventCategory, eventAction, eventLabel);
+  }
+}

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,6 +1,7 @@
 import '@cagov/ds-site-navigation';
 import '@cagov/ds-page-feedback';
 import '@cagov/ds-page-navigation';
+import './ga-tracking.js';
 // import '@zachleat/seven-minute-tabs';
 // import { augmentSevenMinuteTabs } from './seven-minute-tabs-augment.js';
 // window.addEventListener('load',augmentSevenMinuteTabs);


### PR DESCRIPTION
Add the code for GA to track external link tracks in preparation for the DIF application form button being added which we want to track.

We don't have cooperation from vendor to do conversion tracking yet so this is just generic offsite link events