### PR TITLE
Render HTML entities in title tag

### DIFF
--- a/pages/_includes/base-layout.njk
+++ b/pages/_includes/base-layout.njk
@@ -8,7 +8,7 @@
     <meta content="Office of Innovation - State of California" name="author">
     <link href="https://www.google-analytics.com" rel="preconnect">
     <meta content="#000000" name="theme-color">
-    <title>{% if title %}{{ title }}{% else %}California Office of Digital Innovation{% endif %}{% if title != "Office of Digital Innovation" %} | Office of Digital Innovation{% endif %}</title>
+    <title>{% if title %}{{ title | safe }}{% else %}California Office of Digital Innovation{% endif %}{% if title != "Office of Digital Innovation" %} | Office of Digital Innovation{% endif %}</title>
 
     <meta name="description" content="{{ data.og_meta.page_description | striptags }}" />
     <link rel="icon" href="/img/favicon.png">


### PR DESCRIPTION
Upon updating the DIF page, we discovered HTML entities were not rendering in the `<title>` tag. This PR fixes this problem.

<img width="498" alt="Screen Shot 2022-06-07 at 09 41 20" src="https://user-images.githubusercontent.com/1208960/172436851-da79c25a-05f9-4415-a87f-d82d52c8e313.png">
