### PR TITLE
Change menu item to "meet the team"

### DIFF
--- a/pages/_includes/site-navigation.njk
+++ b/pages/_includes/site-navigation.njk
@@ -46,7 +46,7 @@
             <div class="expanded-menu-dropdown" id="who-we-are">
                 <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/who-we-are/our-vision/" tabindex="-1">Our vision</a>
                 <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/who-we-are/how-we-work/" tabindex="-1">How we work</a>
-                <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/who-we-are/staff-and-alumni/" tabindex="-1">Staff and alumni</a>              
+                <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/who-we-are/meet-the-team/" tabindex="-1">Meet the team</a>              
             </div>
           </div>
         </div>


### PR DESCRIPTION
Changes the "Staff and alumni" site navigation menu item to "Meet the team". Also updates the corresponding URL.

We should wait until the page is updated before we merge this PR.

We'll also need to put a redirect into the S3 bucket's static website settings, as follows.

```json
    {
        "Condition": {
            "HttpErrorCodeReturnedEquals": "404",
            "KeyPrefixEquals": "who-we-are/staff-and-alumni/"
        },
        "Redirect": {
            "HostName": "digital.ca.gov",
            "HttpRedirectCode": "302",
            "Protocol": "https",
            "ReplaceKeyPrefixWith": "who-we-are/meet-the-team/"
        }
    }
```