### PR TITLE
meet the team has no sections, both that and current our work page sh…

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -104,8 +104,8 @@ module.exports = function (eleventyConfig) {
         if (!item.data.layout) {
           item.data.layout = "content";
         }
-        if(item.url.indexOf('our-work') > -1) {
-          item.data.layout = 'single-column-conditional';
+        if(item.url.indexOf('our-work') > -1 || item.url.indexOf('meet-the-team') > -1) {
+          item.data.layout = 'single-column';
         }
         item.data.title = jsonData.title;
         item.data.publishdate = jsonData.date.split("T")[0]; //new Date(jsonData.modified_gmt)


### PR DESCRIPTION
…ould use single column page because they don't want the header image

This is a code change that fixes a padding problem on the "our work" page: At medium screen widths there was no left padding on the title. It also gives the same layout hardcoded for the current "meet the team" page because that no longer has any subheadings so the internal page navigation was not rendering.