### PR TITLE
switch remaining domain references in code

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -59,7 +59,7 @@ module.exports = function (eleventyConfig) {
     let output = [];
 
     collection.getAll().forEach((item) => {
-      item.data.domain = 'digital.ca.gov';
+      item.data.domain = 'innovation.ca.gov';
       if (item.inputPath.includes(FolderNamePosts)) {
         item.outputPath = item.outputPath.replace(`/${FolderNamePosts}`, "");
         item.url = item.url.replace(`/${FolderNamePosts}`, "");

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -1,5 +1,5 @@
-name: Deploy PROD digital.ca.gov
-# site:  development.digital.ca.gov
+name: Deploy PROD innovation.ca.gov
+# site:  development.innovation.ca.gov
 on:
   push:
     branches:

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# digital.ca.gov
+# innovation.ca.gov
 Office of Data & Innovation website
 
 
 ## Blog
 
-Our blog originally on news.alpha.ca.gov has been moved here so it is deployed to [digital.ca.gov/blog](https://digital.ca.gov/blog/)
+Our blog originally on news.alpha.ca.gov has been moved here so it is deployed to [innovation.ca.gov/blog](https://innovation.ca.gov/blog/)
 
 ### Writing posts
 
 To write a new post:
 
-- Add it here...[Wordpress for digital.ca.gov](https://live-digital-ca-gov.pantheonsite.io/.pantheonsite.io/wp-admin/edit.php)
+- Add it here...[Wordpress for innovation.ca.gov](https://live-digital-ca-gov.pantheonsite.io/.pantheonsite.io/wp-admin/edit.php)
 
 ## Deployment
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "digital.ca.gov",
+  "name": "innovation.ca.gov",
   "version": "1.0.0",
   "description": "Office of Data & Innovation website",
   "main": "index.js",

--- a/pages/_includes/base-layout.njk
+++ b/pages/_includes/base-layout.njk
@@ -21,7 +21,7 @@
     <meta property="og:description" content="{{ data.og_meta.open_graph_description | striptags }}" />
     <meta property="og:title" content="{{ title | safe }}" />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="{% if data.og_meta.page_social_image_url %}{{ data.og_meta.page_social_image_url | changeDomain(domain) }}{% else %}{% if previewimage %}/{{ previewimage }}{% else %}https://digital.ca.gov/img/ODI-socialmedia-share_1200x630.png{% endif %}{% endif %}" />
+    <meta property="og:image" content="{% if data.og_meta.page_social_image_url %}{{ data.og_meta.page_social_image_url | changeDomain(domain) }}{% else %}{% if previewimage %}/{{ previewimage }}{% else %}https://innovation.ca.gov/img/ODI-socialmedia-share_1200x630.png{% endif %}{% endif %}" />
     <meta property="og:image:width" content="{% if data.og_meta.page_social_image_url %}{{ data.og_meta.page_social_image_width }}{% else %}{% if previewimage %}608{% else %}1200{% endif %}{% endif %}" />
     <meta property="og:image:height" content="{% if data.og_meta.page_social_image_url %}{{ data.og_meta.page_social_image_height }}{% else %}{% if previewimage %}304{% else %}630{% endif %}{% endif %}" />
     <meta property="og:image:alt" content="{% if data.og_meta.page_social_image_alt %}{{ data.og_meta.page_social_image_alt }}{% endif %}" />
@@ -29,7 +29,7 @@
     <meta property="og:site_name" content="{{ data.og_meta.site_name }}" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="{{ data.og_meta.twitter_title | safe }}" />
-    <meta property="twitter:image" content="{% if data.og_meta.page_social_image_url %}{{ data.og_meta.page_social_image_url | changeDomain(domain) }}{% else %}{% if previewimage %}/{{ previewimage }}{% else %}https://digital.ca.gov/img/ODI-socialmedia-share_1200x630.png{% endif %}{% endif %}" />
+    <meta property="twitter:image" content="{% if data.og_meta.page_social_image_url %}{{ data.og_meta.page_social_image_url | changeDomain(domain) }}{% else %}{% if previewimage %}/{{ previewimage }}{% else %}https://innovation.ca.gov/img/ODI-socialmedia-share_1200x630.png{% endif %}{% endif %}" />
     <meta property="twitter:image:alt" content="{% if data.og_meta.page_social_image_alt %}{{ data.og_meta.page_social_image_alt }}{% endif %}" />
     <meta property="twitter:image:width" content="{% if data.og_meta.page_social_image_url %}{{ data.og_meta.page_social_image_width }}{% else %}{% if previewimage %}608{% else %}1200{% endif %}{% endif %}" />
     <meta property="twitter:image:height" content="{% if data.og_meta.page_social_image_url %}{{ data.og_meta.page_social_image_height }}{% else %}{% if previewimage %}304{% else %}630{% endif %}{% endif %}" />

--- a/pages/manual-content/sitemap.njk
+++ b/pages/manual-content/sitemap.njk
@@ -7,7 +7,7 @@ eleventyExcludeFromCollections: true
   {% for page in collections.all %}
     {% if not sitemap.urls[page.url | url ].exclude %}
       <url>
-        <loc>https://digital.ca.gov{{ page.url | url }}</loc>
+        <loc>https://innovation.ca.gov{{ page.url | url }}</loc>
         <lastmod>{{ page.date.toISOString() }}</lastmod>
         <changefreq>daily</changefreq>
       </url>


### PR DESCRIPTION
There were some references to digital.ca.gov in code, time to remove all of these in preparation for launch of site on new domain

This fixes the problem noticed yesterday with social share image from new blog post not showing up because the url was using digital.ca but we are currently only deploying to innovation.ca and we haven't enabled the full site redirect on digital.ca yet