### PR TITLE
V1.0.4 new feedback domain

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "innovation.ca.gov",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Office of Data & Innovation website",
   "main": "index.js",
   "devDependencies": {

--- a/pages/_includes/site-footer.njk
+++ b/pages/_includes/site-footer.njk
@@ -1,5 +1,5 @@
 {% if page.url !== "/error.html" %}
-  <cagov-page-feedback class="cagov-mb-2 d-block" data-endpoint-url="https://fa-go-feedback-001.azurewebsites.net/sendfeedback"></cagov-page-feedback>
+  <cagov-page-feedback class="cagov-mb-2 d-block" data-endpoint-url="https://feedback.innovation.ca.gov/sendfeedback"></cagov-page-feedback>
 {% endif %}
 
 <section aria-label="Site footer" class="site-footer">


### PR DESCRIPTION
The page feedback initial data collection system has been migrated from Azure to AWS and now has a friendly domain name under our control.

This update points the feedback widget on the ODI site to this new API