### PR TITLE
use black for scores that are below 90 for sufficient contrast

### DIFF
--- a/src/css/_par-scores.scss
+++ b/src/css/_par-scores.scss
@@ -41,10 +41,10 @@
   border-color: currentColor;
 }
 .speedlify-score-ok {
-  color: #ffa400;
-  border-color: currentColor;
+  color: #000;
+  border-color: #ffa400;
 }
 .speedlify-score-bad {
-  color: #ff4e42;
+  color: #000;
   border-color: currentColor;
 }


### PR DESCRIPTION
This fixes the currently broken build which discovered a color contrast issue when we have lower PAR scores