### PR TITLE
Noto serif font change

### DIFF
--- a/pages/_includes/base-layout.njk
+++ b/pages/_includes/base-layout.njk
@@ -10,7 +10,10 @@
     <meta content="IE=edge" http-equiv="X-UA-Compatible">
     <meta content="width=device-width,initial-scale=1" name="viewport">
     <meta content="Office of Innovation - State of California" name="author">
-    <link href="https://www.google-analytics.com" rel="preconnect">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://www.google-analytics.com">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Serif:wght@700&display=swap" rel="stylesheet">
     <meta content="#000000" name="theme-color">
     <title>{% if title %}{{ title | striptags | fixEntities | safe }}{% else %}California Office of Data and Innovation{% endif %}{% if title != "Office of Data and Innovation" %} | Office of Data and Innovation{% endif %}</title>
 

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -11,7 +11,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(https://fonts.gstatic.com/s/notoserif/v21/ga6Law1J5X9T9RW6j9bNdOwzfReece9LOoc.woff2) format('woff2');
+  // src: url(https://fonts.gstatic.com/s/notoserif/v21/ga6Law1J5X9T9RW6j9bNdOwzfReece9LOoc.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;  
 }
   


### PR DESCRIPTION
Changed to same font origin/method as hub, to avoid header flicker when changing between the two sites.

The problem:

<img width="1200" height="288" alt="image" src="https://github.com/user-attachments/assets/ac681f1b-eae2-4a61-a370-146f6798a528" />
(Hard to notice, but kerning is slightly different, look at the two ffs in "Office")

The hub and innovation sites are using slightly different versions of Noto Serif (and likely Noto Sans) due to sourcing from different locations.  Since we aligning the design on both sites, I want to make sure the fonts are identical, so that differences in Kerning don't cause the titles to wiggle when you navigate from one to the other.  The version of the font used by the hub is the latest (v33?) while the version used by this site (v21) is pegged to that version due to a difference in the way it was implemented.