### PR TITLE
Fix CodeQL alerts: regex escapes, URL hostname check, workflow permissions

### DIFF
--- a/.github/workflows/deploy_dev_aws.yml
+++ b/.github/workflows/deploy_dev_aws.yml
@@ -9,6 +9,9 @@ concurrency: # replaces use of n1hility/cancel-previous-runs
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build_deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -11,6 +11,9 @@ concurrency: # replaces use of n1hility/cancel-previous-runs
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build_deploy:
     runs-on: ubuntu-latest

--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -115,7 +115,7 @@ export default function (eleventyConfig) {
         );
       }
       // Replace Wordpress media paths with correct 11ty output path.
-      const regexPattern = `http[^"']+?pantheonsite\.io/wp-content/uploads/`;
+      const regexPattern = `http[^"']+?pantheonsite\\.io/wp-content/uploads/`;
       content = content.replace(new RegExp(regexPattern, 'g'), `/${wordpressImagePath}/`);
     }
 

--- a/pages/_data/eleventyComputed.js
+++ b/pages/_data/eleventyComputed.js
@@ -199,8 +199,17 @@ function isPlaceholderNavigationPage(article) {
 const getPermalink = (article) => {
   if (isPage(article)) {
     const url = article.data.wordpress_url;
-    if (url && url.includes(".pantheonsite.io/"))
-      return url.split(".pantheonsite.io/")[1] || "/";
+    if (url) {
+      // Check the actual hostname rather than a substring of the whole URL.
+      try {
+        const parsed = new URL(url);
+        if (parsed.hostname.endsWith(".pantheonsite.io")) {
+          return parsed.pathname.replace(/^\//, "") || "/";
+        }
+      } catch {
+        // Not a parseable URL; fall through and return it unchanged.
+      }
+    }
     return url;
   }
 

--- a/pages/_includes/search.njk
+++ b/pages/_includes/search.njk
@@ -92,7 +92,7 @@
 		.insertBefore(gcse, s[s.length - 1]);
 
 	const urlParam = function (name) {
-		var results = new RegExp('[\?&]' + name + '=([^&#]*)').exec(window.location.search);
+		var results = new RegExp('[?&]' + name + '=([^&#]*)').exec(window.location.search);
 
 		return (results !== null)
 			? results[1] || 0


### PR DESCRIPTION
## Summary

Resolves all 5 open CodeQL alerts.

| Alert | Severity | Fix |
|---|---|---|
| #6 `js/useless-regexp-character-escape` (`eleventy.config.mjs`) | high | Real bug: in a template literal, `\.` collapses to `.` before reaching `RegExp`, so the WordPress media-path pattern matched *any* character where a literal dot was intended. Now `\\.`. |
| #5 `js/useless-regexp-character-escape` (`search.njk`) | high | Removed the useless `\?` escape inside a character class (`[?&]` — `?` is already literal there; behavior unchanged). |
| #3 `js/incomplete-url-substring-sanitization` (`eleventyComputed.js`) | high | `url.includes(".pantheonsite.io/")` matched the substring anywhere in the URL. Now parses with `new URL()` and checks `hostname.endsWith(".pantheonsite.io")`, extracting the permalink from `pathname`. The data is build-time trusted (our own WordPress export), so this is hardening rather than a live vulnerability. |
| #2, #1 `actions/missing-workflow-permissions` (both deploy workflows) | medium | Added `permissions: contents: read` — the workflows only check out and build; AWS access comes from secrets, not the `GITHUB_TOKEN`. |

## Verification

The permalink function determines output paths for every page, so the build was compared against a pre-change baseline:

- `npm run build`: zero errors, Copied 1457 / Wrote 123 — unchanged.
- File list in `_site` (1,580 files) is **identical** to baseline.
- All page URLs in `allFiles.json` are **identical** to baseline.
- WordPress media URLs still rewritten: 0 remaining `pantheonsite.io/wp-content/uploads` references in built HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)