### PR TITLE
Match site-navigation link colors to hub.innovation.ca.gov

### DIFF
--- a/src/css/_theme-overrides.scss
+++ b/src/css/_theme-overrides.scss
@@ -18,6 +18,14 @@ cagov-site-navigation, .site-header {
   background: transparent;
   border-bottom: solid 1px var(--primary-color, #0D4F8C);
 }
+/* Match the nav colors used on hub.innovation.ca.gov so the shared header
+   doesn't change color when navigating between the two sites. The nav
+   component reads --primary-700 (link text) and --primary-900 (hover/focus);
+   left unset they fall back to brighter blues (#165ac2 / #003588). */
+cagov-site-navigation {
+  --primary-700: var(--primary-color, #0D4F8C);
+  --primary-900: #003484;
+}
 h1, h2, h3, h4, h5, h6 {
   color: var(--primary-color, #0D4F8C);
   font-family: 'Noto Serif', serif;


### PR DESCRIPTION
## Summary

The pull-down site navigation is being adopted on hub.innovation.ca.gov (cagov/hub.innovation.ca.gov#133) so the two sites share a consistent header. The nav link text there renders in the site primary blue (`#0D4F8C`), matching surrounding page text, while this site's nav renders a brighter blue — so the header visibly changes color when navigating between the sites.

## Cause

`@cagov/ds-site-navigation` styles its links with `var(--primary-700, #165ac2)` and hover/focus with `var(--primary-900, #003588)`. This site's theme never defines those tokens, so the nav falls back to the brighter defaults. The hub defines them as `#0D4F8C` / `#003484`.

## Change

One scoped rule in `_theme-overrides.scss` defining both tokens on `cagov-site-navigation`, tying link text to `--primary-color`:

```scss
cagov-site-navigation {
  --primary-700: var(--primary-color, #0D4F8C);
  --primary-900: #003484;
}
```

Scoped to the nav rather than `:root` because the only other consumer of these tokens on this site is a mailchimp form border — this keeps the change surgical.

## Verification

Compared both sites side by side in a local browser (this repo's dev server vs the hub's `jbum-new-homepage` branch): computed nav link color, hover/focus token, nav bar height, and position now all match exactly. All other nav tokens (fonts, spacing, focus outline color) were already identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)