### PR TITLE
Fix js-yaml 4.x DoS vulnerability (Dependabot alert #90)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -257,9 +257,9 @@
       }
     },
     "node_modules/@11ty/eleventy/node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

Resolves the open high-severity Dependabot alert [#90](https://github.com/cagov/innovation.ca.gov/security/dependabot/90): **js-yaml: YAML merge-key chains can force quadratic CPU consumption** (affects js-yaml >= 4.0.0, < 4.3.0).

- Bumps `js-yaml` 4.2.0 → 4.3.0 in `package-lock.json` only — no `package.json` changes
- The vulnerable copy is `@11ty/eleventy`'s direct dependency; its `^4.1.1` range already permits 4.3.0, so no overrides were needed
- The other js-yaml in the tree (`3.15.0`, nested under `gray-matter`) is outside this advisory's vulnerable range

## Verification

- `npm audit`: 0 vulnerabilities
- `npm run build`: full Eleventy build completes cleanly (123 files written)

## Risk

Low — js-yaml is only used at build time (YAML front-matter/data parsing); it is not part of the deployed site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)