### PR TITLE
Pin js-yaml to non-vulnerable versions via npm overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -257,9 +257,9 @@
       }
     },
     "node_modules/@11ty/eleventy/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -1990,6 +1990,19 @@
         "node": ">=6.0"
       }
     },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/gunning-fog": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/gunning-fog/-/gunning-fog-1.0.6.tgz",
@@ -2264,19 +2277,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0"
-      }
-    },
-    "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/junk": {

--- a/package.json
+++ b/package.json
@@ -57,5 +57,11 @@
   "homepage": "https://github.com/cagov/digital.ca.gov#readme",
   "volta": {
     "node": "18.15.0"
+  },
+  "overrides": {
+    "js-yaml": "^4.3.1",
+    "gray-matter": {
+      "js-yaml": "^3.15.1"
+    }
   }
 }


### PR DESCRIPTION
## Problem

The [Dependabot Updates run](https://github.com/cagov/innovation.ca.gov/actions/runs/31746510432) failed with `security_update_not_possible` for `js-yaml`:

> `@11ty/eleventy@3.1.6` requires `js-yaml@^3.13.1` via `gray-matter@4.0.3`
> js-yaml can't be automatically updated to a non-vulnerable version.

This is not a regression from the brace-expansion merge (#435) — the push to `main` just re-triggered Dependabot's security updates, and this separate js-yaml advisory has no automatic fix.

The advisory is [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) / CVE-2026-59870 (high, quadratic CPU consumption in `!!omap` resolution). Affected ranges: `>=3.0.0 <3.15.1` and `>=4.0.0 <4.3.1`.

`@11ty/eleventy` pulls in js-yaml twice:

```
@11ty/eleventy@3.1.6
├─┬ gray-matter@4.0.3
│ └── js-yaml@3.15.0   ← vulnerable
└── js-yaml@4.3.0      ← vulnerable
```

3.1.6 is the latest eleventy release, so there is no upgrade path out of it.

## Fix

Add scoped npm `overrides`:

```json
"overrides": {
  "js-yaml": "^4.3.1",
  "gray-matter": {
    "js-yaml": "^3.15.1"
  }
}
```

The advisory is fixed in **both** release lines, so gray-matter can stay on 3.x. That scoping is deliberate: gray-matter 4.0.3 calls `yaml.safeLoad` / `yaml.safeDump` ([lib/engines.js:16-17](https://github.com/jonschlinkert/gray-matter/blob/master/lib/engines.js)), which js-yaml 4 removed — a blanket `^4.3.1` override would break front matter parsing across the whole site.

## Verification

Resulting tree:

```
@11ty/eleventy@3.1.6
├─┬ gray-matter@4.0.3 overridden
│ └── js-yaml@3.15.1 overridden
└── js-yaml@4.3.1 overridden
```

- `npm audit` → `found 0 vulnerabilities`
- `npm run build` → `Copied 1269 Wrote 125 files in 3.92 seconds (v3.1.6)`

These overrides can be removed once eleventy ships a release depending on non-vulnerable js-yaml in both paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)